### PR TITLE
Making this repo Draft only unitl kep is merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DRAFT ONLY : UNTIL KEP IS MERGED 
+  https://github.com/kubernetes/enhancements/pull/1383
+
 # Container Object Storage Specification
 
 Kubernetes specific Container Object Storage Interface (COSI) components.


### PR DESCRIPTION
This repo will be WIP repo until kep mentioned is merged.
For now the repo is used to run some Proof of Concept work required to flush out unknowns.

/sig storage
/assign @xing-yang @saad-ali