### PR TITLE
release-tools: support arm64

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -68,9 +68,10 @@ ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 build-%: check-go-version-go
 	mkdir -p bin
 	CGO_ENABLED=0 GOOS=linux go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$* ./cmd/$*
-	if [ "$$ARCH" = "amd64" ]; then \
+	if [ "$(ARCH)" = "amd64" ]; then \
 		CGO_ENABLED=0 GOOS=windows go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*.exe ./cmd/$* ; \
 		CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*-ppc64le ./cmd/$* ; \
+		CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o ./bin/$*-arm64 ./cmd/$* ; \
 	fi
 
 container-%: build-%


### PR DESCRIPTION
Looks a more reasonable approach is to support true multi-arch docker images as csi release tools does [1]. Will follow up improving.

[1] https://github.com/kubernetes-csi/csi-release-tools