### PR TITLE
Update README.md to redirect to new monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# MOVED: **This repo has been moved to https://github.com/kubernetes-sigs/container-object-storage-interface : see `proto` directory**
+
+
 ![version](https://img.shields.io/badge/status-pre--alpha-lightgrey)
 
 # Container Object Storage Interface Spec


### PR DESCRIPTION
Update readme to redirect users to new monorepo:
https://github.com/kubernetes-sigs/container-object-storage-interface